### PR TITLE
Tag with full zone name

### DIFF
--- a/modules/archive/variables.tf
+++ b/modules/archive/variables.tf
@@ -5,6 +5,7 @@ variable "zone" {
     environment = string,
     region      = string,
     name        = string,
+    full_name   = string,
     az          = string,
     is_cd       = bool,
   })

--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -28,7 +28,7 @@ resource "aws_vpc" "main" {
   tags = {
     Name           = var.zone.name
     managedby      = "vespa-cloud"
-    zone           = var.zone.name
+    zone           = var.zone.full_name
     archive_bucket = module.archive.bucket
   }
 }

--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -5,6 +5,7 @@ variable "zone" {
     environment = string,
     region      = string,
     name        = string,
+    full_name   = string,
     az          = string,
     is_cd       = bool,
   })

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,7 +26,7 @@ locals {
   zones_by_env = {
     for zone in local.all_zones :
     zone.environment => merge(
-    { name = "${zone.environment}.${zone.region}", is_cd = var.is_cd, az = local.az_by_region[zone.region], full_name = "${zone.environment}.${zone.region}"}, zone)...
+    { name = "${zone.environment}.${zone.region}", is_cd = var.is_cd, az = local.az_by_region[zone.region], full_name = "${zone.environment}.${zone.region}" }, zone)...
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,7 +26,7 @@ locals {
   zones_by_env = {
     for zone in local.all_zones :
     zone.environment => merge(
-    { name = "${zone.environment}.${zone.region}", is_cd = var.is_cd, az = local.az_by_region[zone.region] }, zone)...
+    { name = "${zone.environment}.${zone.region}", is_cd = var.is_cd, az = local.az_by_region[zone.region], full_name = "${zone.environment}.${zone.region}"}, zone)...
   }
 }
 


### PR DESCRIPTION
Unfortunately we are using different zone name format in publiccd (e.g. `dev.aws-use-1c`), change the tag to be the full name (e.g. `dev.aws-us-east-1c`)