### PR TITLE
Fix zone name in resources

### DIFF
--- a/modules/archive/variables.tf
+++ b/modules/archive/variables.tf
@@ -5,7 +5,7 @@ variable "zone" {
     environment = string,
     region      = string,
     name        = string,
-    full_name   = string,
+    tag         = string,
     az          = string,
     is_cd       = bool,
   })

--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -26,9 +26,9 @@ resource "aws_vpc" "main" {
   assign_generated_ipv6_cidr_block = true
   enable_dns_hostnames             = true
   tags = {
-    Name           = var.zone.name
+    Name           = var.zone.tag # TODO Change to zone.name
     managedby      = "vespa-cloud"
-    zone           = var.zone.full_name
+    zone           = var.zone.name
     archive_bucket = module.archive.bucket
   }
 }
@@ -52,7 +52,7 @@ resource "aws_subnet" "hosts" {
   assign_ipv6_address_on_creation = true
   availability_zone               = data.aws_availability_zone.current.name
   tags = {
-    Name      = "${var.zone.name}-subnet-tenant"
+    Name      = "${var.zone.tag}-subnet-tenant" # TODO: Change to zone.name
     managedby = "vespa-cloud"
   }
 }
@@ -64,7 +64,7 @@ resource "aws_subnet" "lb" {
   assign_ipv6_address_on_creation = true
   availability_zone               = data.aws_availability_zone.current.name
   tags = {
-    Name      = "${var.zone.name}-subnet-tenantelb"
+    Name      = "${var.zone.tag}-subnet-tenantelb"
     managedby = "vespa-cloud"
   }
 }

--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -5,7 +5,7 @@ variable "zone" {
     environment = string,
     region      = string,
     name        = string,
-    full_name   = string,
+    tag         = string,
     az          = string,
     is_cd       = bool,
   })

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,24 +9,24 @@ locals {
     aws-ap-northeast-1a = "apne1-az4",
   }
   all_zones = var.is_cd ? [
-    { environment = "dev", region = "aws-us-east-1c", name = "dev.aws-use-1c" },
-    { environment = "test", region = "aws-us-east-1c", name = "test.aws-use-1c" },
-    { environment = "staging", region = "aws-us-east-1c", name = "staging.aws-use-1c" },
-    { environment = "prod", region = "aws-us-east-1c", name = "prod.aws-use-1c" },
+    { environment = "dev", region = "aws-us-east-1c", tag = "dev.aws-use-1c" },
+    { environment = "test", region = "aws-us-east-1c", tag = "test.aws-use-1c" },
+    { environment = "staging", region = "aws-us-east-1c", tag = "staging.aws-use-1c" },
+    { environment = "prod", region = "aws-us-east-1c", tag = "prod.aws-use-1c" },
     ] : [
-    { environment = "dev", region = "aws-us-east-1c" },
-    { environment = "test", region = "aws-us-east-1c" },
-    { environment = "staging", region = "aws-us-east-1c" },
-    { environment = "perf", region = "aws-us-east-1c" },
-    { environment = "prod", region = "aws-us-east-1c" },
-    { environment = "prod", region = "aws-us-west-2a" },
-    { environment = "prod", region = "aws-eu-west-1a" },
-    { environment = "prod", region = "aws-ap-northeast-1a" },
+    { environment = "dev", region = "aws-us-east-1c", tag = "dev.aws-use-1c" },
+    { environment = "test", region = "aws-us-east-1c", tag = "test.aws-use-1c" },
+    { environment = "staging", region = "aws-us-east-1c", tag = "staging.aws-use-1c" },
+    { environment = "perf", region = "aws-us-east-1c", tag = "perf.aws-use-1c" },
+    { environment = "prod", region = "aws-us-east-1c", tag = "prod.aws-use-1c" },
+    { environment = "prod", region = "aws-us-west-2a", tag = "prod.aws-usw-2a" },
+    { environment = "prod", region = "aws-eu-west-1a", tag = "prod.aws-euw-1a" },
+    { environment = "prod", region = "aws-ap-northeast-1a", tag = "prod.aws-apne-1a" },
   ]
   zones_by_env = {
     for zone in local.all_zones :
     zone.environment => merge(
-    { name = "${zone.environment}.${zone.region}", is_cd = var.is_cd, az = local.az_by_region[zone.region], full_name = "${zone.environment}.${zone.region}" }, zone)...
+    { name = "${zone.environment}.${zone.region}", is_cd = var.is_cd, az = local.az_by_region[zone.region] }, zone)...
   }
 }
 


### PR DESCRIPTION
There are 2 resources that configserver looks up using the `Name` tag: The VPC and the subnet.
Configserver expects that their name contains the availability zone, but the format of this availability zone varies because we changed it over time and changing it on existing zones is not trivial, so they were stuck with the old names. But if we can get everything in terraform, it'll be much easier. For now I've added the special `tag` field for those 2 resources while everything else will be tagged using the full zone name.