### PR TITLE
Allow key creator full control over the KMS key

### DIFF
--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -422,20 +422,7 @@ data "aws_iam_policy_document" "ebs_key" {
   statement {
     effect = "Allow"
 
-    actions = [
-      "kms:Create*",
-      "kms:Describe*",
-      "kms:Enable*",
-      "kms:List*",
-      "kms:Put*",
-      "kms:Update*",
-      "kms:Revoke*",
-      "kms:Disable*",
-      "kms:Get*",
-      "kms:Delete*",
-      "kms:ScheduleKeyDeletion",
-      "kms:CancelKeyDeletion"
-    ]
+    actions = [ "kms:*" ]
 
     principals {
       type        = "AWS"


### PR DESCRIPTION
Either we do this, or we need to add at least 2 more permissions: `kms:TagResource` and `kms:UntagResource` in case we change the value on one of the tags or drop it entirely.