### PR TITLE
S3 defaults is not to use ACLs

### DIFF
--- a/modules/archive/main.tf
+++ b/modules/archive/main.tf
@@ -23,9 +23,11 @@ resource "aws_s3_bucket" "archive" {
   }
 }
 
-resource "aws_s3_bucket_acl" "archive" {
+resource "aws_s3_bucket_ownership_controls" "archive" {
   bucket = aws_s3_bucket.archive.id
-  acl    = "private"
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_versioning" "archive" {


### PR DESCRIPTION
In April 2023 AWS changed the defaults for new S3 buckets.  This update takes this into account.

See: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/