### PR TITLE
Don't download external modules for checkov

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,3 +28,4 @@ jobs:
         uses: bridgecrewio/checkov-action@master
         with:
           framework: terraform
+          download_external_modules: false


### PR DESCRIPTION
Checkov downloads external modules by default, but we don't have any external modules.

However we do have examples that reference this module as present on Terraform registry.  This causes checkov to against older version of this module, which can block merging PRs.