### PR TITLE
Revert "Enforce that zones must have IP ranges within 10.0.0.0/8"

### DIFF
--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -11,16 +11,12 @@ variable "zone" {
   })
 }
 
-locals {
-  valid_ipv4_subnets = tolist([for x in range(0, 256) : cidrsubnet("10.0.0.8/8", 8, x)])
-}
-
 variable "zone_ipv4_cidr" {
   description = "CIDR for zone network"
   type        = string
   default     = "10.128.0.0/16"
   validation {
-    condition = try(cidrnetmask(var.zone_ipv4_cidr), null) == "255.255.0.0" && contains(locals.valid_ipv4_subnets, var.zone_ipv4_cidr)
-    error_message = "CIDR for the zone network must be /16 and must be within 10.0.0.0/8"
+    condition = try(cidrnetmask(var.zone_ipv4_cidr), null) == "255.255.0.0" && !contains(cidrsubnets("172.16.0.0/15", 1, 1), var.zone_ipv4_cidr)
+    error_message = "CIDR for the zone network must be /16 and cannot overlap with 172.16.0.0/15"
   }
 }


### PR DESCRIPTION
Reverts vespa-cloud/terraform-aws-enclave#32

Fails with:

[19:36:28.076] The Terraform configuration must be valid before initialization so that
[19:36:28.076] Terraform can determine which modules and providers need to be installed.
[19:36:28.076] 
[19:36:28.076] Error: Invalid reference in variable validation
[19:36:28.076] 
[19:36:28.076]   on .terraform/modules/zone_prod_us_east_1c/modules/zone/variables.tf line 23, in variable "zone_ipv4_cidr":
[19:36:28.076]   23:     condition = try(cidrnetmask(var.zone_ipv4_cidr), null) == "255.255.0.0" && contains(locals.valid_ipv4_subnets, var.zone_ipv4_cidr)
[19:36:28.076] 
[19:36:28.076] The condition for variable "zone_ipv4_cidr" can only refer to the variable
[19:36:28.076] itself, using var.zone_ipv4_cidr.