### PR TITLE
ec2:CreateVolume is needed for in-place OS upgrade

### DIFF
--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -20,7 +20,8 @@ data "aws_iam_policy_document" "provision_policy" {
     actions = [
       "ec2:CreateTags",
       "ec2:RunInstances",
-      "ec2:TerminateInstances"
+      "ec2:TerminateInstances",
+      "ec2:CreateVolume"
     ]
     resources = [
       "arn:aws:ec2:*:*:image/*",


### PR DESCRIPTION
When we do in-place OS upgrades we explicitly create an EBS volume that gets attached to the EC2 instances.  To be able to do this we need the ec2:CreateVolume privilege.