### PR TITLE
Allow overriding the AWS AZ when setting up a zone

### DIFF
--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -10,10 +10,11 @@ terraform {
 locals {
   hosts_cidr_block      = cidrsubnet(var.zone_ipv4_cidr, 1, 1)
   hosts_ipv6_cidr_block = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 1)
+  zone_az               = coalesce(var.zone_az, var.zone.az)
 }
 
 data "aws_availability_zone" "current" {
-  zone_id = var.zone.az
+  zone_id = locals.zone_az
 }
 
 module "archive" {

--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -20,3 +20,10 @@ variable "zone_ipv4_cidr" {
     error_message = "CIDR for the zone network must be /16 and must be within 10.0.0.0/8"
   }
 }
+
+variable "zone_az" {
+  description = "Override AWS AZ for Vespa Cloud zone (EXPERIMENTAL)"
+  type        = string
+  default     = null
+  nullable    = true
+}


### PR DESCRIPTION
There's a 1:1 mapping between Vespa Cloud zones and an AWS AZ. Here we introduce an experimental setting where customers can override the AZ used in their Enclave accounts.