### PR TITLE
Delegate all KMS actions to account IAM

### DIFF
--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -405,11 +405,7 @@ data "aws_iam_policy_document" "ebs_key" {
     effect = "Allow"
 
     actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey"
+      "kms:*"
     ]
 
     principals {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 
 locals {
-  template_version = "1.0.9"
+  template_version = "1.1.0"
   zones_by_env = {
     for zone in var.all_zones :
     zone.environment => merge(


### PR DESCRIPTION
In order to avoid losing admin access to the KMS key by deleting the original creator we delegate all IAM policy rights to the account IAM configuration.