### PR TITLE
Limit cloud provisioner permissions

### DIFF
--- a/modules/archive/main.tf
+++ b/modules/archive/main.tf
@@ -48,6 +48,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "archive" {
     expiration {
       days = 31
     }
+    filter {}
     abort_incomplete_multipart_upload {
       days_after_initiation = 7
     }

--- a/modules/archive/main.tf
+++ b/modules/archive/main.tf
@@ -88,6 +88,11 @@ resource "aws_kms_key" "archive" {
   }
 }
 
+resource "aws_kms_alias" "archive" {
+  name          = "alias/vespa-archive-key-${var.zone.environment}-${var.zone.region}"
+  target_key_id = aws_kms_key.archive.key_id
+}
+
 data "aws_iam_policy_document" "archive" {
   #checkov:skip=CKV_AWS_109:Needed to keep backwards compatibility
   #checkov:skip=CKV_AWS_111:Needed to keep backwards compatibility

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -135,13 +135,19 @@ resource "aws_iam_role" "vespa_cloud_provisioner_role" {
       }
     ]
   })
-  managed_policy_arns = [
-    aws_iam_policy.vespa_cloud_provision_policy.arn,
-    aws_iam_policy.vespa_cloud_backup_expiry_policy.arn,
-  ]
   tags = {
     managedby = "vespa-cloud"
   }
+}
+
+resource "aws_iam_role_policy_attachment" "provision" {
+  role       = aws_iam_role.vespa_cloud_provisioner_role.name
+  policy_arn = aws_iam_policy.vespa_cloud_provision_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.vespa_cloud_provisioner_role.name
+  policy_arn = aws_iam_policy.vespa_cloud_backup_expiry_policy.arn
 }
 
 resource "aws_iam_policy" "vespa_cloud_provision_policy" {

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -44,10 +44,27 @@ data "aws_iam_policy_document" "provision_policy" {
     effect = "Allow"
   }
 
+
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = ["*"]
+    effect    = "Deny"
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:RoleName"
+      values   = [aws_iam_role.vespa_cloud_tenant_host_service.name]
+    }
+  }
   statement {
     actions   = ["iam:PassRole"]
     resources = [aws_iam_role.vespa_cloud_tenant_host_service.arn]
     effect    = "Allow"
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ec2.amazonaws.com"]
+    }
   }
 
   statement {

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -56,39 +56,25 @@ data "aws_iam_policy_document" "provision_policy" {
       "kms:GenerateDataKeyWithoutPlaintext",
       "kms:ReEncryptFrom",
       "kms:ReEncryptTo",
-      "route53:ChangeResourceRecordSets",
-      "route53:GetChange"
+      "kms:ListAliases",
+      "kms:ListKeys",
     ]
     resources = [
       "arn:aws:kms:*:*:key/*",
-      "arn:aws:route53:::change/*",
-      "arn:aws:route53:::hostedzone/*"
     ]
     effect = "Allow"
   }
 
   statement {
-    actions = ["route53:GetChange", "route53:ChangeResourceRecordSets"]
-    resources = [
-      "arn:aws:ec2:*:*:image/*",
-      "arn:aws:ec2:*:*:instance/*",
-      "arn:aws:ec2:*:*:security-group/*",
-      "arn:aws:ec2:*:*:network-interface/*",
-      "arn:aws:ec2:*:*:subnet/*",
-      "arn:aws:ec2:*:*:volume/*"
+    actions = [
+      "elasticloadbalancing:*"
     ]
-    effect = "Allow"
-  }
-
-  statement {
-    actions   = ["elasticloadbalancing:*"]
     resources = ["*"]
     effect    = "Allow"
   }
 
   statement {
     actions = [
-      "cognito-idp:DescribeUserPoolClient",
       "ec2:AssignPrivateIpAddresses",
       "ec2:CreateTags",
       "ec2:CreateVpcEndpointServiceConfiguration",
@@ -117,10 +103,6 @@ data "aws_iam_policy_document" "provision_policy" {
       "ec2:ModifyVpcEndpointServicePermissions",
       "ec2:StartInstances",
       "ec2:StartVpcEndpointServicePrivateDnsVerification",
-      "kms:ListAliases",
-      "kms:ListKeys",
-      "route53:ListHostedZones",
-      "sts:AssumeRole",
     ]
     resources = ["*"]
     effect    = "Allow"

--- a/modules/ssh/main.tf
+++ b/modules/ssh/main.tf
@@ -26,10 +26,14 @@ resource "aws_iam_role" "vespa_ssh_login_role" {
       }
     ]
   })
-  managed_policy_arns = [aws_iam_policy.vespa_ssh_login_policy.arn]
   tags = {
     managedby = "vespa-cloud"
   }
+}
+
+resource "aws_iam_role_policy_attachment" "ssh_login" {
+  role       = aws_iam_role.vespa_ssh_login_role.name
+  policy_arn = aws_iam_policy.vespa_ssh_login_policy.arn
 }
 
 resource "aws_iam_policy" "vespa_ssh_login_policy" {

--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -508,6 +508,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "backup" {
   rule {
     id     = "remove-incomplete"
     status = "Enabled"
+    filter {}
     abort_incomplete_multipart_upload {
       days_after_initiation = 2
     }

--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -536,6 +536,11 @@ resource "aws_kms_key" "backup" {
   enable_key_rotation = true
 }
 
+resource "aws_kms_alias" "backup" {
+  name          = "alias/vespa-backup-key-${local.zone.environment}-${local.zone.region}"
+  target_key_id = aws_kms_key.backup.key_id
+}
+
 resource "aws_kms_key_policy" "backup" {
   key_id = aws_kms_key.backup.id
   policy = jsonencode({

--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -561,7 +561,9 @@ resource "aws_kms_key_policy" "backup" {
           "kms:Get*",
           "kms:Delete*",
           "kms:ScheduleKeyDeletion",
-          "kms:CancelKeyDeletion"
+          "kms:CancelKeyDeletion",
+          "kms:TagResource",
+          "kms:UntagResource",
         ],
         "Resource" : "*"
       },

--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -365,7 +365,7 @@ resource "aws_vpc_endpoint" "interface" {
   security_group_ids  = [aws_security_group.sg.id]
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
+  service_name        = "com.amazonaws.${data.aws_region.current.id}.${each.key}"
   tags = {
     Name      = "vespa-${replace(each.key, ".", "-")}-${local.zone.name}"
     managedby = "vespa-cloud"
@@ -381,7 +381,7 @@ resource "aws_vpc_endpoint" "ecr_s3" {
   vpc_id            = aws_vpc.main.id
   route_table_ids   = [aws_route_table.hosts.id]
   vpc_endpoint_type = "Gateway"
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name      = "com.amazonaws.${data.aws_region.current.id}.s3"
   tags = {
     Name      = "vespa-s3gw-${local.zone.name}"
     managedby = "vespa-cloud"


### PR DESCRIPTION
 * Use resource tags to limit KMS access
 * Remove, now unused actions