### PR TITLE
Add ec2:DescribeInstanceTypeOfferings permission

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.4.0"
+  template_version = "1.5.0"
 }
 
 terraform {

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -57,13 +57,13 @@ data "aws_iam_policy_document" "provision_policy" {
 
   statement {
     actions = [
+      "kms:CreateGrant",
+      "kms:Decrypt",
       "kms:DescribeKey",
       "kms:Encrypt",
-      "kms:Decrypt",
       "kms:GenerateDataKeyWithoutPlaintext",
       "kms:ReEncryptFrom",
       "kms:ReEncryptTo",
-      "kms:CreateGrant",
     ]
     resources = [
       "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*",
@@ -79,12 +79,12 @@ data "aws_iam_policy_document" "provision_policy" {
   // AMI key
   statement {
     actions = [
-      "kms:DescribeKey",
-      "kms:ReEncryptFrom",
-      "kms:ReEncryptTo",
+      "kms:CreateGrant",
       "kms:Decrypt",
+      "kms:DescribeKey",
       "kms:GenerateDataKeyWithoutPlainText",
-      "kms:CreateGrant"
+      "kms:ReEncryptFrom",
+      "kms:ReEncryptTo"
     ]
     resources = [
       "arn:aws:kms:*:${var.vespa_cloud_account}:key/*",
@@ -127,15 +127,14 @@ data "aws_iam_policy_document" "provision_policy" {
       "ec2:CreateTags",
       "ec2:CreateVpcEndpointServiceConfiguration",
       "ec2:DeleteVpcEndpointServiceConfigurations",
-      "ec2:RejectVpcEndpointConnections",
       "ec2:DescribeAccountAttributes",
       "ec2:DescribeAddresses",
       "ec2:DescribeClassicLinkInstances",
       "ec2:DescribeCoipPools",
       "ec2:DescribeImages",
+      "ec2:DescribeInstances",
       "ec2:DescribeInstanceStatus",
       "ec2:DescribeInstanceTypeOfferings",
-      "ec2:DescribeInstances",
       "ec2:DescribeInternetGateways",
       "ec2:DescribeNetworkInterfaces",
       "ec2:DescribeRouteTables",
@@ -151,6 +150,7 @@ data "aws_iam_policy_document" "provision_policy" {
       "ec2:GetCoipPoolUsage",
       "ec2:ModifyVpcEndpointServiceConfiguration",
       "ec2:ModifyVpcEndpointServicePermissions",
+      "ec2:RejectVpcEndpointConnections",
       "ec2:StartInstances",
       "ec2:StartVpcEndpointServicePrivateDnsVerification",
     ]
@@ -261,8 +261,8 @@ resource "aws_iam_policy" "vespa_cloud_host_backup_policy" {
         Sid    = "TenantHostAccess",
         Effect = "Allow",
         Action = [
-          "s3:PutObject",
-          "s3:GetObject"
+          "s3:GetObject",
+          "s3:PutObject"
         ],
         # Snapshot content is stored under /snapshots/<hostname>/<uuid>/
         Resource = "arn:aws:s3:::${local.bucket_resource_name}/snapshots/*/*/*"

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -134,6 +134,7 @@ data "aws_iam_policy_document" "provision_policy" {
       "ec2:DescribeCoipPools",
       "ec2:DescribeImages",
       "ec2:DescribeInstanceStatus",
+      "ec2:DescribeInstanceTypeOfferings",
       "ec2:DescribeInstances",
       "ec2:DescribeInternetGateways",
       "ec2:DescribeNetworkInterfaces",


### PR DESCRIPTION
Add ec2:DescribeInstanceTypeOfferings permission to ensure flavor generation upgrades are only attempted when the newer generation is available in the current Access Zone.
<!--
Versioning & tagging quick guide:

- Regular PRs: bump `locals.template_version` in `main.tf`.
- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.

See more details in .github/CONTRIBUTING.md.
-->

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-aws-enclave/blob/main/.github/CONTRIBUTING.md).
