### PR TITLE
Allow provisioner role to delete EC2 tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.6.0"
+  template_version = "1.6.1"
 }
 
 terraform {

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -25,6 +25,7 @@ data "aws_iam_policy_document" "provision_policy" {
       "ec2:AttachVolume",
       "ec2:CreateTags",
       "ec2:CreateVolume",
+      "ec2:DeleteTags",
       "ec2:DeleteVolume",
       "ec2:DetachVolume",
       "ec2:ModifyInstanceAttribute",


### PR DESCRIPTION
Adds `ec2:DeleteTags` to the `vespa-cloud-provisioner` policy so that `CloudResourceTagMaintainer` can remove tags from instances and EBS volumes when a custom resource tag is renamed or removed in `deployment.xml`.

Without this permission the maintainer fails with `403 AuthorizationFailed` on `ec2:DeleteTags` against the volume ARN. The action is added to the existing statement scoped to instance/volume/etc. resources; no new statement and no broader scope.

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)