### PR TITLE
[minor] complete working example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ IAM role, SSO). See https://registry.terraform.io/providers/hashicorp/aws/latest
 Since Vespa Cloud spans multiple AWS regions, you need one AWS provider per region. The root module
 sets up global IAM resources, and each zone submodule creates region-specific networking.
 
+Production deployments in Vespa Cloud go through a CI/CD pipeline that requires `test` and
+`staging` zones in addition to your `prod` zones. A `dev` zone is also typically set up for
+manual development deployments. The example below sets up all four environments.
+
 ```hcl
 provider "aws" {
   alias  = "us_east_1"
@@ -56,9 +60,42 @@ module "enclave" {
   source      = "vespa-cloud/enclave/aws"
   version     = ">= 1.0.0, < 2.0.0"
   tenant_name = "<YOUR-VESPA-TENANT-NAME>"
+  providers = {
+    aws = aws.us_east_1
+  }
 }
 
-# Create one Vespa Cloud zone (VPC, subnets, NAT gateway, security groups, etc.)
+# Dev zone for manual development deployments
+module "zone_dev_us_east_1c" {
+  source  = "vespa-cloud/enclave/aws//modules/zone"
+  version = ">= 1.0.0, < 2.0.0"
+  zone    = module.enclave.zones.dev.aws_us_east_1c
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
+# Test and staging zones are required by the Vespa Cloud CI/CD pipeline
+# before changes can be promoted to prod.
+module "zone_test_us_east_1c" {
+  source  = "vespa-cloud/enclave/aws//modules/zone"
+  version = ">= 1.0.0, < 2.0.0"
+  zone    = module.enclave.zones.test.aws_us_east_1c
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
+module "zone_staging_us_east_1c" {
+  source  = "vespa-cloud/enclave/aws//modules/zone"
+  version = ">= 1.0.0, < 2.0.0"
+  zone    = module.enclave.zones.staging.aws_us_east_1c
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
+# Production zones (add as many as you need)
 module "zone_prod_us_east_1c" {
   source  = "vespa-cloud/enclave/aws//modules/zone"
   version = ">= 1.0.0, < 2.0.0"


### PR DESCRIPTION
A customer (naturally) copied the example from the README, which has a prod zone, but no dev, system and staging zones. 
That made the customers first deployment be a prod deployment, which, naturally failed due to missing system and staging zones. 
 
Think we should make the README example more complete. 
Suggest the changes in this PR. 

This is out of my known territory, so please review if it makes sense. 


<!--
Versioning & tagging quick guide:

- Regular PRs: bump `locals.template_version` in `main.tf`.
- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.

See more details in .github/CONTRIBUTING.md.
-->

### Intent (select one)

- [ ] Regular - bumped version `locals.template_version` in `main.tf`
- [x] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-aws-enclave/blob/main/.github/CONTRIBUTING.md).
