### PR TITLE
Support custom EBS KMS Key policy statements

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,3 +8,6 @@ Terraform modules.
 
 [`multi-region`](./multi-region/)
 : An example that shows a full set up with support for the CI/CD pipeline and two production zones.
+
+[`custom-ebs-kms-key-policy`](./custom-ebs-kms-key-policy/)
+: An example that shows how to extend the EBS KMS key policy to grant an external principal (e.g. an agentless security scanner) access to encrypted volumes.

--- a/examples/custom-ebs-kms-key-policy/main.tf
+++ b/examples/custom-ebs-kms-key-policy/main.tf
@@ -1,0 +1,54 @@
+
+#
+# Set up the AWS Terraform Provider to point to the region where
+# you want to provision the Vespa Cloud Enclave.
+#
+provider "aws" {
+  region = "us-east-1"
+}
+
+#
+# Set up the basic module that grants Vespa Cloud permission to
+# provision Vespa Cloud resources inside the AWS account.
+#
+module "enclave" {
+  source      = "vespa-cloud/enclave/aws"
+  version     = ">= 1.0.0, < 2.0.0"
+  tenant_name = "<YOUR-TENANT-HERE>"
+}
+
+#
+# Define a custom EBS KMS key policy to grant an external principal access
+# to the key. A common use case is agentless security scanning, where a role
+# in a separate scanner account needs read access to encrypted EBS volumes.
+#
+data "aws_iam_policy_document" "ebs_kms_key_extra" {
+  statement {
+    sid    = "AllowAgentlessScanner"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::<SCANNER-ACCOUNT-ID>:role/<SCANNER-ROLE-NAME>"]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:GenerateDataKeyWithoutPlaintext",
+      "kms:ReEncrypt*",
+    ]
+    resources = ["*"]
+  }
+}
+
+#
+# Set up the VPC that will contain the Enclaved Vespa application for the dev environment.
+# The custom_ebs_kms_key_policy extends the EBS encryption key policy to allow the
+# external scanner role defined above to access encrypted volumes.
+#
+module "zone_dev_us_east_1c" {
+  source  = "vespa-cloud/enclave/aws//modules/zone"
+  version = ">= 1.0.0, < 2.0.0"
+  zone    = module.enclave.zones.dev.aws_us_east_1c
+
+  custom_ebs_kms_key_policy = data.aws_iam_policy_document.ebs_kms_key_extra.json
+}

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.6.1"
+  template_version = "1.7.0"
 }
 
 terraform {

--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -398,6 +398,13 @@ data "aws_iam_session_context" "current" {
   arn = data.aws_caller_identity.current.arn
 }
 
+data "aws_iam_policy_document" "ebs_key_merged" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.ebs_key.json,
+    var.custom_ebs_kms_key_policy,
+  ]
+}
+
 data "aws_iam_policy_document" "ebs_key" {
   policy_id = "key-default-1"
 
@@ -482,7 +489,7 @@ resource "aws_kms_key" "ebs" {
   description             = "Key used for EBS encryption on Vespa instances"
   key_usage               = "ENCRYPT_DECRYPT"
   enable_key_rotation     = true
-  policy                  = data.aws_iam_policy_document.ebs_key.json
+  policy                  = data.aws_iam_policy_document.ebs_key_merged.json
   deletion_window_in_days = 7
   tags = {
     managedby = "vespa-cloud"

--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -33,3 +33,9 @@ variable "archive_reader_principals" {
   type        = list(string)
   default     = []
 }
+
+variable "custom_ebs_kms_key_policy" {
+  description = "Any custom ebs kms key policy required. This can be to grant account external roles access to the key for agentless scanning or similar. Pass the json output from a `aws_iam_policy_document` data resource as the value"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Support custom EBS KMS Key policy statements to enable access to the KMS key for principals outside the enclave account.

<!--
Versioning & tagging quick guide:

- Regular PRs: bump `locals.template_version` in `main.tf`.
- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.

See more details in .github/CONTRIBUTING.md.
-->

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)
