### PR TITLE
Fix null custom_ebs_kms_key_policy in source_policy_documents

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.7.0"
+  template_version = "1.7.1"
 }
 
 terraform {

--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -399,10 +399,10 @@ data "aws_iam_session_context" "current" {
 }
 
 data "aws_iam_policy_document" "ebs_key_merged" {
-  source_policy_documents = [
+  source_policy_documents = compact([
     data.aws_iam_policy_document.ebs_key.json,
     var.custom_ebs_kms_key_policy,
-  ]
+  ])
 }
 
 data "aws_iam_policy_document" "ebs_key" {


### PR DESCRIPTION
PR #95 added `var.custom_ebs_kms_key_policy` to the `source_policy_documents` list in `ebs_key_merged`, but the variable defaults to `null`. Terraform does not accept null entries in `source_policy_documents`, so every zone that does not explicitly set this variable fails with "Null value found in list".

Fix: wrap the list with `compact()` to filter out null entries.

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)