### PR TITLE
Add core dump bucket and customer-gated read access

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ This module is published on both the Terraform and OpenTofu registries.
 ## What this module sets up
 - IAM roles for the Vespa Cloud provisioner and tenant hosts
 - IAM policies granting the provisioner permission to manage EC2 instances, EBS volumes, load balancers, KMS keys and VPC endpoint services
-- IAM policies for tenant hosts to upload to archive buckets, access ECR container images and use SSM
+- IAM policies for tenant hosts to upload to archive and core dump buckets, access ECR container images and use SSM
 - An instance profile for the tenant host service role
 
-Networking (VPC, subnets, NAT gateway, security groups, VPC endpoints, KMS keys, S3 archive/backup buckets)
+Networking (VPC, subnets, NAT gateway, security groups, VPC endpoints, KMS keys, S3 archive/backup/coredump buckets)
 is created per-zone via the `modules/zone` submodule after the root module has been applied.
 
 ## Requirements

--- a/examples/multi-region/main.tf
+++ b/examples/multi-region/main.tf
@@ -49,6 +49,19 @@ module "enclave" {
 # }
 
 #
+# Grant the Vespa team time-limited, read-only access to encrypted core dumps.
+# Only needed when Vespa Cloud support asks for core dump access.
+#
+# module "coredump_access" {
+#   source  = "vespa-cloud/enclave/aws//modules/coredump-access"
+#   version = ">= 1.8.0, < 2.0.0"
+#   read_access_expires_at = "2026-07-01T00:00:00Z"
+#   providers = {
+#     aws = aws.us_east_1
+#   }
+# }
+
+#
 # Set up the VPC that will contain the Enclaved Vespa appplication.
 #
 

--- a/examples/multi-region/main.tf
+++ b/examples/multi-region/main.tf
@@ -46,6 +46,9 @@ module "enclave" {
 # module "ssh" {
 #   source  = "vespa-cloud/enclave/aws//modules/ssh"
 #   vespa_cloud_account = module.enclave.vespa_cloud_account
+#   providers = {
+#     aws = aws.us_east_1
+#   }
 # }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.7.3"
+  template_version = "1.8.0"
 }
 
 terraform {

--- a/modules/coredump-access/README.md
+++ b/modules/coredump-access/README.md
@@ -1,0 +1,34 @@
+# Core dump read access
+
+An optional module to grant the Vespa Cloud operations team time-limited, read-only
+access to the encrypted core dumps stored in this account's core dump buckets.
+
+Only use this module when Vespa Cloud support has asked for access to a core dump,
+and you explicitly wish to grant it. Access is read-only, limited to the core dump
+buckets, and is automatically denied after the expiry time you set in
+`read_access_expires_at`. Extending access requires updating the timestamp and
+re-applying.
+
+Core dumps are compressed and encrypted on the Vespa host before they are written
+to the bucket. The decryption key is held by Vespa Cloud; this module only grants
+access to the encrypted bytes.
+
+Instantiate this module **once per account**, not per zone. It creates IAM
+resources with fixed names, and the access it grants covers the core dump
+buckets of all zones in the account.
+
+```terraform
+module "enclave" {
+  source      = "vespa-cloud/enclave/aws"
+  version     = ">= 1.0.0, < 2.0.0"
+  tenant_name = "<vespa cloud tenant>"
+}
+
+module "coredump_access" {
+  source                 = "vespa-cloud/enclave/aws//modules/coredump-access"
+  version                = ">= 1.8.0, < 2.0.0"
+  read_access_expires_at = "2026-07-01T00:00:00Z"
+}
+```
+
+To revoke access before the expiry time, remove the module and apply.

--- a/modules/coredump-access/README.md
+++ b/modules/coredump-access/README.md
@@ -9,6 +9,10 @@ buckets, and is automatically denied after the expiry time you set in
 `read_access_expires_at`. Extending access requires updating the timestamp and
 re-applying.
 
+`read_access_expires_at` is unset (`null`) by default, which creates no IAM
+resources and grants no access. You can keep the module block in your
+configuration permanently and only set the timestamp when access is needed.
+
 Core dumps are compressed and encrypted on the Vespa host before they are written
 to the bucket. The decryption key is held by Vespa Cloud; this module only grants
 access to the encrypted bytes.
@@ -31,4 +35,5 @@ module "coredump_access" {
 }
 ```
 
-To revoke access before the expiry time, remove the module and apply.
+To revoke access before the expiry time, unset `read_access_expires_at` (or
+remove the module) and apply.

--- a/modules/coredump-access/main.tf
+++ b/modules/coredump-access/main.tf
@@ -1,0 +1,102 @@
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+locals {
+  debug_account_id = split(":", var.debug_instance_role_arn)[4]
+}
+
+# Role assumed by Vespa Cloud debug instances to read encrypted core dumps
+# from the core dump buckets in this account. All access is automatically
+# denied after the expiry time given in var.read_access_expires_at.
+#
+# The trust policy uses the debug account root as principal with an
+# aws:PrincipalArn condition instead of naming the role directly. IAM
+# validates named role principals on write, so a direct reference would
+# break if the debug instance role does not exist yet, or is recreated.
+resource "aws_iam_role" "coredump_read" {
+  name        = "vespa-coredump-read"
+  description = "Allows Vespa Cloud debug instances time-limited read access to core dump buckets"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRole"
+        Principal = {
+          AWS = "arn:aws:iam::${local.debug_account_id}:root"
+        }
+        Condition = {
+          ArnEquals = {
+            "aws:PrincipalArn" = var.debug_instance_role_arn
+          }
+          DateLessThan = {
+            "aws:CurrentTime" = var.read_access_expires_at
+          }
+        }
+      }
+    ]
+  })
+  tags = {
+    managedby = "vespa-cloud"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "coredump_read" {
+  role       = aws_iam_role.coredump_read.name
+  policy_arn = aws_iam_policy.coredump_read.arn
+}
+
+resource "aws_iam_policy" "coredump_read" {
+  #checkov:skip=CKV_AWS_356:KMS statement requires Resource '*', constrained by alias and ViaService conditions
+  name = "vespa-coredump-read-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadCoredumpBuckets"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = [
+          "arn:aws:s3:::vespa-coredump-*",
+        ]
+        Condition = {
+          DateLessThan = {
+            "aws:CurrentTime" = var.read_access_expires_at
+          }
+        }
+      },
+      { # Allow S3 to decrypt core dump bucket objects (SSE-KMS) on read
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+        Condition = {
+          StringLike = {
+            "kms:ViaService" = "s3.*.amazonaws.com"
+          }
+          "ForAnyValue:StringLike" = {
+            "kms:ResourceAliases" = "alias/vespa-coredump-key-*"
+          }
+          DateLessThan = {
+            "aws:CurrentTime" = var.read_access_expires_at
+          }
+        }
+      }
+    ]
+  })
+  tags = {
+    managedby = "vespa-cloud"
+  }
+}

--- a/modules/coredump-access/main.tf
+++ b/modules/coredump-access/main.tf
@@ -9,6 +9,9 @@ terraform {
 
 locals {
   debug_account_id = split(":", var.debug_instance_role_arn)[4]
+  # Grant access only when an expiry time is set. Unset (null) creates no
+  # IAM resources, so customers can keep the module block present but inert.
+  enabled = var.read_access_expires_at == null ? 0 : 1
 }
 
 # Role assumed by Vespa Cloud debug instances to read encrypted core dumps
@@ -20,6 +23,7 @@ locals {
 # validates named role principals on write, so a direct reference would
 # break if the debug instance role does not exist yet, or is recreated.
 resource "aws_iam_role" "coredump_read" {
+  count       = local.enabled
   name        = "vespa-coredump-read"
   description = "Allows Vespa Cloud debug instances time-limited read access to core dump buckets"
   assume_role_policy = jsonencode({
@@ -48,13 +52,15 @@ resource "aws_iam_role" "coredump_read" {
 }
 
 resource "aws_iam_role_policy_attachment" "coredump_read" {
-  role       = aws_iam_role.coredump_read.name
-  policy_arn = aws_iam_policy.coredump_read.arn
+  count      = local.enabled
+  role       = aws_iam_role.coredump_read[0].name
+  policy_arn = aws_iam_policy.coredump_read[0].arn
 }
 
 resource "aws_iam_policy" "coredump_read" {
   #checkov:skip=CKV_AWS_356:KMS statement requires Resource '*', constrained by alias and ViaService conditions
-  name = "vespa-coredump-read-policy"
+  count = local.enabled
+  name  = "vespa-coredump-read-policy"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/modules/coredump-access/outputs.tf
+++ b/modules/coredump-access/outputs.tf
@@ -1,5 +1,5 @@
 
 output "role_arn" {
-  description = "ARN of the core dump read role assumed by Vespa Cloud debug instances"
-  value       = aws_iam_role.coredump_read.arn
+  description = "ARN of the core dump read role assumed by Vespa Cloud debug instances, or null when no access is granted"
+  value       = one(aws_iam_role.coredump_read[*].arn)
 }

--- a/modules/coredump-access/outputs.tf
+++ b/modules/coredump-access/outputs.tf
@@ -1,0 +1,5 @@
+
+output "role_arn" {
+  description = "ARN of the core dump read role assumed by Vespa Cloud debug instances"
+  value       = aws_iam_role.coredump_read.arn
+}

--- a/modules/coredump-access/variables.tf
+++ b/modules/coredump-access/variables.tf
@@ -1,0 +1,15 @@
+
+variable "read_access_expires_at" {
+  description = "RFC 3339 UTC timestamp when core dump read access expires, e.g. 2026-07-01T00:00:00Z. All access granted by this module is automatically denied after this time. A timestamp in the past is valid but grants no access."
+  type        = string
+  validation {
+    condition     = can(formatdate("YYYY", var.read_access_expires_at)) && can(regex("Z$", var.read_access_expires_at))
+    error_message = "Must be an RFC 3339 UTC timestamp ending in Z, e.g. 2026-07-01T00:00:00Z."
+  }
+}
+
+variable "debug_instance_role_arn" {
+  description = "ARN of the IAM role used by Vespa Cloud debug instances"
+  type        = string
+  default     = "arn:aws:iam::061361823659:role/vespa-debug-instance"
+}

--- a/modules/coredump-access/variables.tf
+++ b/modules/coredump-access/variables.tf
@@ -1,9 +1,11 @@
 
 variable "read_access_expires_at" {
-  description = "RFC 3339 UTC timestamp when core dump read access expires, e.g. 2026-07-01T00:00:00Z. All access granted by this module is automatically denied after this time. A timestamp in the past is valid but grants no access."
+  description = "RFC 3339 UTC timestamp when core dump read access expires, e.g. 2026-07-01T00:00:00Z. All access granted by this module is automatically denied after this time. Leave unset (null) to grant no access at all."
   type        = string
+  default     = null
+  nullable    = true
   validation {
-    condition     = can(formatdate("YYYY", var.read_access_expires_at)) && can(regex("Z$", var.read_access_expires_at))
+    condition     = var.read_access_expires_at == null || can(formatdate("YYYY", var.read_access_expires_at)) && can(regex("Z$", var.read_access_expires_at))
     error_message = "Must be an RFC 3339 UTC timestamp ending in Z, e.g. 2026-07-01T00:00:00Z."
   }
 }

--- a/modules/coredump/main.tf
+++ b/modules/coredump/main.tf
@@ -1,0 +1,184 @@
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "random_string" "coredump" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "aws_s3_bucket" "coredump" {
+  bucket = "vespa-coredump-${data.aws_caller_identity.current.account_id}-${var.zone.name}-${random_string.coredump.id}"
+  tags = {
+    managedby = "vespa-cloud"
+    zone      = var.zone.name
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "coredump" {
+  bucket = aws_s3_bucket.coredump.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "coredump" {
+  bucket = aws_s3_bucket.coredump.id
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "coredump" {
+  bucket = aws_s3_bucket.coredump.id
+  rule {
+    id     = "expiration-rule"
+    status = "Enabled"
+    expiration {
+      days = 7
+    }
+    filter {}
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 2
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "coredump" {
+  bucket = aws_s3_bucket.coredump.id
+  policy = data.aws_iam_policy_document.coredump.json
+}
+
+resource "aws_s3_bucket_public_access_block" "coredump" {
+  bucket                  = aws_s3_bucket.coredump.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "coredump" {
+  bucket = aws_s3_bucket.coredump.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.coredump.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_kms_key" "coredump" {
+  #checkov:skip=CKV2_AWS_64:Key policy is defined in aws_kms_key_policy.coredump
+  description             = "Encryption key for ${aws_s3_bucket.coredump.bucket} S3 bucket"
+  key_usage               = "ENCRYPT_DECRYPT"
+  enable_key_rotation     = true
+  deletion_window_in_days = 7
+  tags = {
+    managedby = "vespa-cloud"
+  }
+}
+
+resource "aws_kms_alias" "coredump" {
+  name          = "alias/vespa-coredump-key-${var.zone.environment}-${var.zone.region}"
+  target_key_id = aws_kms_key.coredump.key_id
+}
+
+data "aws_iam_policy_document" "coredump" {
+  #checkov:skip=CKV_AWS_109:Root account statement delegates to IAM, same pattern as the archive bucket
+  #checkov:skip=CKV_AWS_111:Root account statement delegates to IAM, same pattern as the archive bucket
+  statement {
+    sid = "SecureTransportOnly"
+
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.coredump.id}",
+      "arn:aws:s3:::${aws_s3_bucket.coredump.id}/*",
+    ]
+
+    actions = ["s3:*"]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+
+  # Defense-in-depth for RS12: only compressed+encrypted dumps (.zst.enc) and
+  # metadata files (.json) can be written. Raw (unencrypted) core files are
+  # rejected even if the upload-side filtering in host-admin fails.
+  statement {
+    sid = "EncryptedDumpsOnly"
+
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    not_resources = [
+      "arn:aws:s3:::${aws_s3_bucket.coredump.id}/*.zst.enc",
+      "arn:aws:s3:::${aws_s3_bucket.coredump.id}/*.json",
+    ]
+
+    actions = ["s3:PutObject"]
+  }
+
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.coredump.id}",
+      "arn:aws:s3:::${aws_s3_bucket.coredump.id}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "kms_coredump" {
+  #checkov:skip=CKV_AWS_109:Root account statement delegates to IAM, same pattern as the archive bucket
+  #checkov:skip=CKV_AWS_111:Root account statement delegates to IAM, same pattern as the archive bucket
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions = [
+      "kms:*"
+    ]
+    resources = [
+      aws_kms_key.coredump.arn
+    ]
+  }
+}
+
+resource "aws_kms_key_policy" "coredump" {
+  key_id = aws_kms_key.coredump.id
+  policy = data.aws_iam_policy_document.kms_coredump.json
+}

--- a/modules/coredump/outputs.tf
+++ b/modules/coredump/outputs.tf
@@ -1,0 +1,5 @@
+
+output "bucket" {
+  description = "ID of Vespa Cloud Enclave core dump bucket"
+  value       = aws_s3_bucket.coredump.id
+}

--- a/modules/coredump/variables.tf
+++ b/modules/coredump/variables.tf
@@ -1,0 +1,9 @@
+
+variable "zone" {
+  description = "Vespa Cloud zone to bootstrap"
+  type = object({
+    environment = string,
+    region      = string,
+    name        = string,
+  })
+}

--- a/modules/internal/regional/main.tf
+++ b/modules/internal/regional/main.tf
@@ -20,6 +20,11 @@ module "archive" {
   archive_reader_principals = var.archive_reader_principals
 }
 
+module "coredump" {
+  source = "../../coredump"
+  zone   = var.zone
+}
+
 resource "aws_vpc" "main" {
   cidr_block                       = var.primary_ipv4_cidr
   assign_generated_ipv6_cidr_block = true
@@ -29,6 +34,7 @@ resource "aws_vpc" "main" {
     managedby              = "vespa-cloud"
     zone                   = var.zone.name
     archive_bucket         = module.archive.bucket
+    coredump_bucket        = module.coredump.bucket
     vespa_template_version = var.zone.template_version
   }
 }

--- a/modules/internal/regional/outputs.tf
+++ b/modules/internal/regional/outputs.tf
@@ -48,3 +48,7 @@ output "eip_ids" {
 output "archive_bucket" {
   value = module.archive.bucket
 }
+
+output "coredump_bucket" {
+  value = module.coredump.bucket
+}

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -223,13 +223,39 @@ resource "aws_iam_policy" "vespa_cloud_host_policy" {
         ]
         Resource = "arn:aws:s3:::vespa-archive-*"
       },
-      { # Allow hosts to generate data key to encrypt when uploading to archive bucket
+      { # Allow hosts to upload encrypted core dumps to their core dump bucket
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:PutObjectTagging",
+        ]
+        Resource = "arn:aws:s3:::vespa-coredump-*"
+      },
+      { # Allow hosts to generate data key to encrypt when uploading to S3 buckets (e.g. archive)
         Effect   = "Allow"
         Action   = "kms:GenerateDataKey"
         Resource = "*"
         Condition = {
           StringLike = {
             "kms:ViaService" : "s3.*.amazonaws.com"
+          }
+        }
+      },
+      { # Allow hosts to upload core dumps with SSE-KMS. Multipart uploads (any dump > a few MB)
+        # require kms:Decrypt in addition to kms:GenerateDataKey. This grants no data read
+        # access: hosts have no s3:GetObject on the core dump buckets.
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+        ]
+        Resource = "*"
+        Condition = {
+          StringLike = {
+            "kms:ViaService" : "s3.*.amazonaws.com"
+          }
+          "ForAnyValue:StringLike" = {
+            "kms:ResourceAliases" = "alias/vespa-coredump-key-*"
           }
         }
       },

--- a/modules/zone/outputs.tf
+++ b/modules/zone/outputs.tf
@@ -48,3 +48,6 @@ output "availability_zone_id" {
 output "availability_zone_name" {
   value = module.zonal.availability_zone_names[0]
 }
+output "coredump_bucket" {
+  value = module.regional.coredump_bucket
+}

--- a/modules/zone_multi_az/outputs.tf
+++ b/modules/zone_multi_az/outputs.tf
@@ -17,6 +17,9 @@ output "security_group_id" {
 output "archive_bucket" {
   value = module.regional.archive_bucket
 }
+output "coredump_bucket" {
+  value = module.regional.coredump_bucket
+}
 output "hosts_cidr_block" {
   value = module.zonal.hosts_cidr_blocks[0]
 }


### PR DESCRIPTION
Adds per-zone S3 storage for encrypted core dumps, and an optional module for customers to grant Vespa Cloud time-limited read access to them.

**New `coredump` module** (instantiated per zone, like `archive`):
- Bucket `vespa-coredump-{account}-{zone}-{suffix}` with SSE-KMS, public access blocked, TLS-only
- 7-day expiration lifecycle rule
- Bucket policy denies uploads not matching `*.zst.enc` / `*.json`; dumps are compressed and encrypted on the host before upload
- Tenant hosts get `s3:PutObject` on `vespa-coredump-*`, plus the `kms:Decrypt` + `kms:GenerateDataKey` required for SSE-KMS multipart uploads, scoped to the coredump key aliases and S3

**New optional `coredump-access` module** (instantiated once per account, like `ssh`):
- Creates a `vespa-coredump-read` role that Vespa Cloud debug instances can assume to fetch encrypted dumps
- Opt-in: `read_access_expires_at` defaults to `null`, which creates no IAM resources, so the module block can stay inert in a customer's config until access is needed
- Once set, access expires automatically at the customer-set UTC timestamp, enforced by `DateLessThan` conditions in both the trust and permission policies

The change is additive for existing enclaves: a new bucket and KMS key per zone, no changes to existing resources beyond a VPC tag and a new Allow statement in the host policy.

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

---
*AI-assisted PR (Claude Opus 4.8) - all changes verified by the author before submission*
