### PR TITLE
minor: show inert coredump_access block in multi-region example

### DIFF
--- a/examples/multi-region/main.tf
+++ b/examples/multi-region/main.tf
@@ -53,16 +53,18 @@ module "enclave" {
 
 #
 # Grant the Vespa team time-limited, read-only access to encrypted core dumps.
-# Only needed when Vespa Cloud support asks for core dump access.
+# Keep this block as-is to grant no access. When Vespa Cloud support asks for
+# access, set read_access_expires_at to a future UTC timestamp and apply; unset
+# it again to revoke.
 #
-# module "coredump_access" {
-#   source  = "vespa-cloud/enclave/aws//modules/coredump-access"
-#   version = ">= 1.8.0, < 2.0.0"
-#   read_access_expires_at = "2026-07-01T00:00:00Z"
-#   providers = {
-#     aws = aws.us_east_1
-#   }
-# }
+module "coredump_access" {
+  source  = "vespa-cloud/enclave/aws//modules/coredump-access"
+  version = ">= 1.8.0, < 2.0.0"
+  # read_access_expires_at = "2026-07-01T00:00:00Z"
+  providers = {
+    aws = aws.us_east_1
+  }
+}
 
 #
 # Set up the VPC that will contain the Enclaved Vespa appplication.


### PR DESCRIPTION
Follow-up to #98. Updates the multi-region example to demonstrate the present-but-inert usage of `coredump-access` instead of the comment-out-to-disable pattern.

- Activates the `module "coredump_access"` block with `read_access_expires_at` commented out, so it defaults to `null` and creates no IAM resources
- NOTE: `ssh` above it stays commented, since it has no inert mode and comment/uncomment is its only toggle

### Intent (select one)

- [ ] Regular - bumped version `locals.template_version` in `main.tf`
- [x] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

---
*AI-assisted PR (Claude Opus 4.8) - all changes verified by the author before submission*