### PR TITLE
Remove random suffix from core dump bucket name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.8.1"
+  template_version = "1.8.2"
 }
 
 terraform {

--- a/modules/coredump/main.tf
+++ b/modules/coredump/main.tf
@@ -4,22 +4,16 @@ terraform {
     aws = {
       source = "hashicorp/aws"
     }
-    random = {
-      source = "hashicorp/random"
-    }
   }
 }
 
 data "aws_caller_identity" "current" {}
 
-resource "random_string" "coredump" {
-  length  = 6
-  special = false
-  upper   = false
-}
-
+# The bucket name is deterministic (no random suffix) so the core dump upload
+# feature flag can be configured with the exact name. Uniqueness is guaranteed
+# by the account id (globally unique) and zone.name (environment + region).
 resource "aws_s3_bucket" "coredump" {
-  bucket = "vespa-coredump-${data.aws_caller_identity.current.account_id}-${var.zone.name}-${random_string.coredump.id}"
+  bucket = "vespa-coredump-${data.aws_caller_identity.current.account_id}-${var.zone.name}"
   tags = {
     managedby = "vespa-cloud"
     zone      = var.zone.name


### PR DESCRIPTION
Makes the core dump bucket name deterministic so the core dump upload feature flag can be configured with the exact bucket name.

- Drops the `random_string` suffix (and the now-unused `random` provider) from the `coredump` module
- Bucket name is now `vespa-coredump-{account_id}-{zone.name}` (e.g. `vespa-coredump-816069168172-prod.aws-us-east-1c`)
- Uniqueness still holds: the account id is globally unique and `zone.name` already includes environment + region, so adding regions cannot collide
- Bumps `template_version` to 1.8.2

Note: this forces replacement of the bucket on accounts that already applied 1.8.x. Nothing writes to the bucket yet (host-admin upload is a later step), so the recreate is harmless.

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

---
*AI-assisted PR (Claude Opus 4.8) - all changes verified by the author before submission*