### PR TITLE
fix: support Terraform/OpenTofu < 1.9 in internal modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.8.2"
+  template_version = "1.8.3"
 }
 
 terraform {

--- a/modules/internal/regional/main.tf
+++ b/modules/internal/regional/main.tf
@@ -14,6 +14,15 @@ data "aws_iam_session_context" "current" {
   arn = data.aws_caller_identity.current.arn
 }
 
+resource "terraform_data" "validations" {
+  lifecycle {
+    precondition {
+      condition     = length(var.secondary_ipv4_cidrs) == max(0, length(var.azs) - 1)
+      error_message = "secondary_ipv4_cidrs length must equal length(azs) - 1."
+    }
+  }
+}
+
 module "archive" {
   source                    = "../../archive"
   zone                      = var.zone

--- a/modules/internal/regional/variables.tf
+++ b/modules/internal/regional/variables.tf
@@ -37,10 +37,6 @@ variable "secondary_ipv4_cidrs" {
   type        = list(string)
   default     = []
   nullable    = false
-  validation {
-    condition     = length(var.secondary_ipv4_cidrs) == max(0, length(var.azs) - 1)
-    error_message = "secondary_ipv4_cidrs length must equal length(azs) - 1."
-  }
 }
 
 variable "primary_natgw_subnet_id" {

--- a/modules/internal/zonal/main.tf
+++ b/modules/internal/zonal/main.tf
@@ -23,6 +23,19 @@ locals {
   ]
 }
 
+resource "terraform_data" "validations" {
+  lifecycle {
+    precondition {
+      condition     = length(var.ipv4_cidrs) == length(var.azs)
+      error_message = "ipv4_cidrs must have the same length as azs."
+    }
+    precondition {
+      condition     = length(var.ipv6_cidr_blocks) == length(var.azs)
+      error_message = "ipv6_cidr_blocks must have the same length as azs."
+    }
+  }
+}
+
 # Subnets
 #
 # Each AZ slice is a /16, further divided in the following networks:

--- a/modules/internal/zonal/variables.tf
+++ b/modules/internal/zonal/variables.tf
@@ -33,19 +33,11 @@ variable "security_group_id" {
 variable "ipv4_cidrs" {
   description = "IPv4 CIDR blocks aligned with var.azs. Index 0 is the primary VPC CIDR; indices 1+ are the secondary CIDR-block associations. Sourced from modules/internal/regional outputs so the dependency on those resources is implicit."
   type        = list(string)
-  validation {
-    condition     = length(var.ipv4_cidrs) == length(var.azs)
-    error_message = "ipv4_cidrs must have the same length as azs."
-  }
 }
 
 variable "ipv6_cidr_blocks" {
   description = "IPv6 /56 CIDR blocks aligned with var.azs. Index 0 is the primary VPC IPv6 CIDR; indices 1+ are the secondary associations."
   type        = list(string)
-  validation {
-    condition     = length(var.ipv6_cidr_blocks) == length(var.azs)
-    error_message = "ipv6_cidr_blocks must have the same length as azs."
-  }
 }
 
 variable "hosts_route_table_id" {


### PR DESCRIPTION
Move cross-variable input checks from variable validation blocks into terraform_data preconditions. Cross-object references in validation blocks require TF/tofu 1.9+ and broke `init` for older users.

Describe your changes here.

<!--
Versioning & tagging quick guide:

- Regular PRs: bump `locals.template_version` in `main.tf`.
- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.

See more details in .github/CONTRIBUTING.md.
-->

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-aws-enclave/blob/main/.github/CONTRIBUTING.md).
