### PR TITLE
Add prod.aws-us-east-1 to all_zones

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.8.3"
+  template_version = "1.8.4"
 }
 
 terraform {

--- a/modules/zone_multi_az/variables.tf
+++ b/modules/zone_multi_az/variables.tf
@@ -13,7 +13,7 @@ variable "zone" {
     template_version = string,
   })
   validation {
-    condition     = length(var.zone.configserver_az) >= 3
+    condition     = var.zone.configserver_az != null && length(var.zone.configserver_az) >= 3
     error_message = "zone.configserver_az must contain at least 3 AWS AZ IDs. This module is for multi-AZ Vespa zones; configservers run in at least 3 AZs for HA. For single-AZ zones, use modules/zone instead."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,7 @@ variable "all_zones" {
     { environment = "test", region = "aws-us-east-1c", tag = "test.aws-use-1c" },
     { environment = "staging", region = "aws-us-east-1c", tag = "staging.aws-use-1c" },
     { environment = "prod", region = "aws-us-east-1c", tag = "prod.aws-use-1c" },
+    { environment = "prod", region = "aws-us-east-1", tag = "prod.aws-us-east-1", configserver_az = ["use1-az2", "use1-az4", "use1-az6"] },
     { environment = "prod", region = "aws-use1-az4", tag = "prod.aws-use1-az4" },
     { environment = "prod", region = "aws-use2-az1", tag = "prod.aws-use2-az1" },
     { environment = "prod", region = "aws-use2-az3", tag = "prod.aws-use2-az3" },


### PR DESCRIPTION
<!--
Versioning & tagging quick guide:

- Regular PRs: bump `locals.template_version` in `main.tf`.
- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.

See more details in .github/CONTRIBUTING.md.
-->

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-aws-enclave/blob/main/.github/CONTRIBUTING.md).
