### PR TITLE
Restrict resource permission on caller account id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.8.5"
+  template_version = "1.8.6"
 }
 
 terraform {

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -34,13 +34,13 @@ data "aws_iam_policy_document" "provision_policy" {
     ]
     resources = [
       "arn:aws:ec2:*:*:image/*",
-      "arn:aws:ec2:*:*:instance/*",
-      "arn:aws:ec2:*:*:network-interface/*",
-      "arn:aws:ec2:*:*:security-group/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:instance/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:network-interface/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:security-group/*",
       "arn:aws:ec2:*::snapshot/*",
-      "arn:aws:ec2:*:*:subnet/*",
-      "arn:aws:ec2:*:*:volume/*",
-      "arn:aws:iam::*:instance-profile/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:subnet/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:volume/*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/*",
     ]
     effect = "Allow"
   }

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "provision_policy" {
   #checkov:skip=CKV_AWS_107: "Ensure IAM policies does not allow credentials exposure"
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
-  #checkov:skip=CKV_AWS_356: TODO - Make this policy stricter, but allow this change since it's just a reformat of an existing policy
+  #checkov:skip=CKV_AWS_356: Remaining statements with 'resources = ["*"]' still need restricting
   policy_id = "provision-policy"
 
   statement {


### PR DESCRIPTION
A minor change - the provision policy was unnecessarily permissive. See VESPANG-3124
<!--
Versioning & tagging quick guide:

- Regular PRs: bump `locals.template_version` in `main.tf`.
- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.

See more details in .github/CONTRIBUTING.md.
-->

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-aws-enclave/blob/main/.github/CONTRIBUTING.md).
