### PR TITLE
minor: Add plan-only tofu smoke test + release gate

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -12,6 +12,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  smoke-test:
+    uses: vespa-engine/gh-actions/.github/workflows/tf-smoke-test.yml@main
   tag-release:
+    needs: smoke-test
     uses: vespa-engine/gh-actions/.github/workflows/tf-tag-release.yml@main
     secrets: inherit

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -32,3 +32,5 @@ jobs:
         uses: bridgecrewio/checkov-action@master
         with:
           framework: terraform
+  smoke-test:
+    uses: vespa-engine/gh-actions/.github/workflows/tf-smoke-test.yml@main

--- a/tests/full/main.tf
+++ b/tests/full/main.tf
@@ -1,0 +1,45 @@
+# Test fixture: composes the root module with the customer-facing submodules,
+# mirroring the integration-test template, but with relative sources so the
+# local (unreleased) code is what gets planned.
+
+module "enclave" {
+  source              = "../.."
+  vespa_cloud_account = "786426250597"
+  tenant_name         = "vespa"
+}
+
+module "zone" {
+  source = "../../modules/zone"
+  zone   = module.enclave.zones.prod.aws_us_east_1c
+  archive_reader_principals = [
+    "arn:aws:iam::786426250597:role/vespa.operator.tenant_vespa",
+  ]
+}
+
+module "zone_multi_az" {
+  source          = "../../modules/zone_multi_az"
+  zone            = module.enclave.zones.prod.aws_us_east_1
+  azs             = ["use1-az1", "use1-az2", "use1-az4", "use1-az5", "use1-az6"]
+  primary_zone_az = "use1-az1"
+  archive_reader_principals = [
+    "arn:aws:iam::786426250597:role/vespa.operator.tenant_vespa",
+  ]
+}
+
+module "ssh" {
+  source              = "../../modules/ssh"
+  vespa_cloud_account = module.enclave.vespa_cloud_account
+}
+
+module "coredump_access" {
+  source                 = "../../modules/coredump-access"
+  read_access_expires_at = "2028-01-01T00:00:00Z"
+}
+
+output "zones" {
+  value = module.enclave.zones
+}
+
+output "vespa_host_role" {
+  value = module.enclave.vespa_host_role
+}

--- a/tests/smoke.tftest.hcl
+++ b/tests/smoke.tftest.hcl
@@ -1,0 +1,106 @@
+# Plan-only smoke test with a mocked AWS provider. Runs without credentials.
+#
+# Catches plan-time regressions: broken variable wiring, for_each/count
+# errors, type mismatches, invalid references between the root module and
+# the customer-facing submodules.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:role/smoke-test"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = {
+      name = "us-east-1"
+    }
+  }
+  mock_data "aws_availability_zone" {
+    defaults = {
+      name = "us-east-1a"
+    }
+  }
+  mock_data "aws_iam_session_context" {
+    defaults = {
+      issuer_arn = "arn:aws:iam::123456789012:role/smoke-test"
+    }
+  }
+
+  # Computed attributes that are parsed/validated at plan time need
+  # plausible fake values instead of the auto-generated random strings.
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/smoke-test"
+    }
+  }
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/smoke-test"
+    }
+  }
+  mock_resource "aws_kms_key" {
+    defaults = {
+      arn = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
+    }
+  }
+  mock_resource "aws_s3_bucket" {
+    defaults = {
+      arn = "arn:aws:s3:::smoke-test-bucket"
+    }
+  }
+  mock_resource "aws_vpc" {
+    defaults = {
+      ipv6_cidr_block = "2600:1f18::/56"
+    }
+  }
+  mock_resource "aws_vpc_ipv6_cidr_block_association" {
+    defaults = {
+      ipv6_cidr_block = "2600:1f18:100::/56"
+    }
+  }
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{}"
+    }
+  }
+}
+
+# Plan the root module on its own, with only the required variable set.
+run "root_module" {
+  command = plan
+
+  variables {
+    tenant_name = "smoke"
+  }
+
+  assert {
+    condition     = output.vespa_cloud_account == "332934501266"
+    error_message = "unexpected default vespa_cloud_account"
+  }
+
+  assert {
+    condition     = output.zones.prod.aws_us_east_1c.az == "use1-az6"
+    error_message = "prod.aws-us-east-1c should map to use1-az6"
+  }
+
+  assert {
+    condition     = length(output.zones.prod.aws_us_east_1.configserver_az) >= 2
+    error_message = "multi-AZ zone should carry multiple configserver AZs"
+  }
+}
+
+# Plan the full customer-shaped composition (root + zone + zone_multi_az +
+# ssh + coredump-access) against the local code.
+run "full_composition" {
+  command = plan
+
+  module {
+    source = "./tests/full"
+  }
+
+  assert {
+    condition     = output.vespa_host_role == "vespa.tenant.vespa.aws-123456789012.tenant-host-service"
+    error_message = "vespa_host_role not derived from caller identity as expected"
+  }
+}


### PR DESCRIPTION
## What

- Add `tests/smoke.tftest.hcl`: a plan-only `tofu test` with a fully mocked AWS provider (no credentials, no real infrastructure). Plans the root module and a full customer-shaped composition (root + zone + zone_multi_az + ssh + coredump-access) via `tests/full/main.tf` with relative sources, so the local code is what gets planned.
- `terraform.yml`: run the smoke test on every PR.
- `tag-release.yml`: run the smoke test as a `needs:` gate before `tag-release`.
- Both call the shared `tf-smoke-test.yml` reusable workflow in vespa-engine/gh-actions.

## Why

Since release automation was added, a tag + GitHub release is published immediately on merge to main and the OpenTofu registry picks it up. The only pre-release checks were `tofu fmt`/`validate` and Checkov; functional integration tests run post-release. A mocked-provider smoke test catches plan-time regressions (broken variable wiring, for_each/count errors, type mismatches, invalid cross-module references) that `tofu validate` misses, and gates the release so a regression cannot reach the registry.

## Tested

- `tofu test` locally: 2 passed, 0 failed.
- `tofu fmt -check` clean.
- No functional change to the module, so no `template_version` bump (minor/internal PR).

### Intent (select one)

- [ ] Regular - bumped version `locals.template_version` in `main.tf`
- [x] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

---
*AI-assisted PR (Claude Opus 4.8) - all changes verified by the author before submission*