### PR TITLE
minor: Make CI fmt check recursive

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           tofu_version: latest
       - name: Format
-        run: tofu fmt -check
+        run: tofu fmt -check -recursive
       - name: Initialize
         run: tofu init -backend=false
       - name: Validate


### PR DESCRIPTION
`tofu fmt -check` only checks the working directory, so the `tests/` files added for the smoke test (and `modules/`) were not format-checked in CI. Add `-recursive` so the whole tree is covered.

Verified `tofu fmt -check -recursive` is clean across the repo, so it won't fail on any pre-existing file. No functional change, no `template_version` bump (minor/internal PR).

### Intent (select one)

- [ ] Regular - bumped version `locals.template_version` in `main.tf`
- [x] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

---
*AI-assisted PR (Claude Opus 4.8) - all changes verified by the author before submission*