### PR TITLE
feat: allow provisioner to manage EC2 Capacity Reservations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.8.8"
+  template_version = "1.8.9"
 }
 
 terraform {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.8.9"
+  template_version = "1.8.10"
 }
 
 terraform {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.8.10"
+  template_version = "1.9.0"
 }
 
 terraform {

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -23,16 +23,20 @@ data "aws_iam_policy_document" "provision_policy" {
   statement {
     actions = [
       "ec2:AttachVolume",
+      "ec2:CancelCapacityReservation",
+      "ec2:CreateCapacityReservation",
       "ec2:CreateTags",
       "ec2:CreateVolume",
       "ec2:DeleteTags",
       "ec2:DeleteVolume",
       "ec2:DetachVolume",
       "ec2:ModifyInstanceAttribute",
+      "ec2:ModifyInstanceCapacityReservationAttributes",
       "ec2:RunInstances",
       "ec2:TerminateInstances"
     ]
     resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:capacity-reservation/*",
       "arn:aws:ec2:*:*:image/*",
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:instance/*",
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:network-interface/*",
@@ -130,6 +134,7 @@ data "aws_iam_policy_document" "provision_policy" {
       "ec2:DeleteVpcEndpointServiceConfigurations",
       "ec2:DescribeAccountAttributes",
       "ec2:DescribeAddresses",
+      "ec2:DescribeCapacityReservations",
       "ec2:DescribeClassicLinkInstances",
       "ec2:DescribeCoipPools",
       "ec2:DescribeImages",

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -23,20 +23,19 @@ data "aws_iam_policy_document" "provision_policy" {
   statement {
     actions = [
       "ec2:AttachVolume",
-      "ec2:CancelCapacityReservation",
-      "ec2:CreateCapacityReservation",
       "ec2:CreateTags",
       "ec2:CreateVolume",
       "ec2:DeleteTags",
       "ec2:DeleteVolume",
       "ec2:DetachVolume",
       "ec2:ModifyInstanceAttribute",
+      // Retargets an instance at a capacity reservation; authorized on the instance, so it cannot be
+      // scoped by the reservation's tags like the statements below
       "ec2:ModifyInstanceCapacityReservationAttributes",
       "ec2:RunInstances",
       "ec2:TerminateInstances"
     ]
     resources = [
-      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:capacity-reservation/*",
       "arn:aws:ec2:*:*:image/*",
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:instance/*",
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:network-interface/*",
@@ -47,6 +46,39 @@ data "aws_iam_policy_document" "provision_policy" {
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/*",
     ]
     effect = "Allow"
+  }
+
+  // Capacity reservations securing host rebuilds: limited to reservations the provisioner manages,
+  // identified by the managed-by tag it always sets on creation
+  statement {
+    actions = [
+      "ec2:CreateCapacityReservation",
+      "ec2:CreateTags",
+    ]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:capacity-reservation/*",
+    ]
+    effect = "Allow"
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/managed-by"
+      values   = ["vespa-cloud-provisioner"]
+    }
+  }
+
+  statement {
+    actions = [
+      "ec2:CancelCapacityReservation",
+    ]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:capacity-reservation/*",
+    ]
+    effect = "Allow"
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/managed-by"
+      values   = ["vespa-cloud-provisioner"]
+    }
   }
 
   statement {

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -53,12 +53,33 @@ data "aws_iam_policy_document" "provision_policy" {
   statement {
     actions = [
       "ec2:CreateCapacityReservation",
+    ]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:capacity-reservation/*",
+    ]
+    effect = "Allow"
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/managed-by"
+      values   = ["vespa-cloud-provisioner"]
+    }
+  }
+
+  // Tag-on-create only: without the CreateAction pin, tagging (and thereby adopting) an existing
+  // reservation would be allowed
+  statement {
+    actions = [
       "ec2:CreateTags",
     ]
     resources = [
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:capacity-reservation/*",
     ]
     effect = "Allow"
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:CreateAction"
+      values   = ["CreateCapacityReservation"]
+    }
     condition {
       test     = "StringEquals"
       variable = "aws:RequestTag/managed-by"

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -29,8 +29,8 @@ data "aws_iam_policy_document" "provision_policy" {
       "ec2:DeleteVolume",
       "ec2:DetachVolume",
       "ec2:ModifyInstanceAttribute",
-      // Retargets an instance at a capacity reservation; authorized on the instance, so it cannot be
-      // scoped by the reservation's tags like the statements below
+      // Retargets an instance at a capacity reservation. This is the instance side of the
+      // authorization; the reservation side is granted, tag-scoped, in its own statement below
       "ec2:ModifyInstanceCapacityReservationAttributes",
       "ec2:RunInstances",
       "ec2:TerminateInstances"
@@ -63,6 +63,12 @@ data "aws_iam_policy_document" "provision_policy" {
       variable = "aws:RequestTag/managed-by"
       values   = ["vespa-cloud-provisioner"]
     }
+    // Only reservations with a bounded end date: the provisioner cannot create standing cost
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:EndDateType"
+      values   = ["limited"]
+    }
   }
 
   // Tag-on-create only: without the CreateAction pin, tagging (and thereby adopting) an existing
@@ -90,6 +96,9 @@ data "aws_iam_policy_document" "provision_policy" {
   statement {
     actions = [
       "ec2:CancelCapacityReservation",
+      // The reservation side of retargeting an instance: the action authorizes on both the instance
+      // (granted above) and the reservation named in the request
+      "ec2:ModifyInstanceCapacityReservationAttributes",
     ]
     resources = [
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:capacity-reservation/*",


### PR DESCRIPTION
## What

Adds EC2 Capacity Reservation permissions to the provisioner policy in the `provision` module:

* `ec2:CreateCapacityReservation`, allowed only when the request tags the reservation with `managed-by = vespa-cloud-provisioner`
* `ec2:CreateTags` on capacity reservations, pinned to tag-on-create (`ec2:CreateAction`) with the same request tag — tagging existing reservations stays denied
* `ec2:CancelCapacityReservation`, allowed only for reservations carrying that same tag (`aws:ResourceTag`)
* `ec2:ModifyInstanceCapacityReservationAttributes` on the existing instance resources — authorized on the instance, so it cannot be scoped by reservation tags
* `ec2:DescribeCapacityReservations` (no resource-level support)

## Why

Vespa Cloud will use On-Demand Capacity Reservations to guarantee that a host can be restarted during maintenance operations (such as OS upgrades) even when instance capacity in the zone is constrained. The reservation is created before the instance is stopped and released once it is running again.

Scoping create/cancel to the `managed-by = vespa-cloud-provisioner` tag keeps the provisioner away from any capacity reservation the account owner creates for their own use.

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

---

_🤖 Built with help of AI._
