### PR TITLE
[VESPANG-2916] Add SSM patch policy S3 permission to tenant-host-service role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.8.8"
+  template_version = "1.8.9"
 }
 
 terraform {

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -271,6 +271,11 @@ resource "aws_iam_policy" "vespa_cloud_host_policy" {
           "ecr:GetDownloadUrlForLayer",
         ]
         Resource = "arn:aws:ecr:*:${var.vespa_cloud_account}:repository/*"
+      },
+      { # Allow SSM Default Host Management patch policy to read its config, needed since attaching AmazonSSMManagedInstanceCore directly overrides the permissions SSM would otherwise grant.
+        Effect   = "Allow"
+        Action   = "s3:GetObject"
+        Resource = "arn:aws:s3:::aws-quicksetup-patchpolicy-*"
       }
     ]
   })


### PR DESCRIPTION
## What
This adds an `s3:GetObject` statement for `arn:aws:s3:::aws-quicksetup-patchpolicy-*` to the `vespa_cloud_host_policy` IAM policy, which is attached to the enclave tenant-host-service role. The change lives in `modules/provision/main.tf` alongside the role's other statements, following the existing per-statement inline-comment pattern. `tofu fmt` and `tofu validate` both pass on the module.

## Why
Enclave customers manually attach `AmazonSSMManagedInstanceCore` directly to their tenant-host-service role, and doing so overrides the permissions that SSM Default Host Management would otherwise grant automatically. Without this statement, the SSM `AWS-RunPatchBaseline` command fails because the role cannot read the patch policy configuration object from the `aws-quicksetup-patchpolicy-*` bucket. This was reported by AWS support and is tracked in VESPANG-2916.